### PR TITLE
feat: Add custom landing page and GitHub Actions for deployment

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy Site with Custom Landing Page to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or 'master' if that's your default branch
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for actions/checkout and for peaceiris/actions-gh-pages to push to gh-pages
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches all history, useful for some MkDocs plugins or versioning
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+          # Add any other mkdocs plugins used in your mkdocs.yml here
+          # For example: pip install mkdocs-mermaid2
+
+      - name: Build MkDocs site
+        run: |
+          mkdocs build --site-dir _mkdocssite
+          # This builds the MkDocs site into a directory named '_mkdocssite'
+
+      - name: Prepare deployment directory
+        run: |
+          mkdir -p public/docs  # Create 'public' and 'public/docs'
+          cp index.html public/index.html # Copy custom landing page to public root
+          cp -r _mkdocssite/* public/docs/ # Copy MkDocs site to public/docs/
+          # If you have a logo file at the root, e.g. logo.png, uncomment the next line:
+          # cp logo.png public/logo.png
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          # By default, this action pushes to the 'gh-pages' branch.
+          # It will create the branch if it doesn't exist.
+          # It will overwrite the existing contents of the branch.
+          # Use 'force_orphan: true' if you want each deploy to be a fresh start without history on gh-pages
+          # cname: your.custom.domain.com # Uncomment if you have a custom domain

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# djlinkgen — IA Generativa para o Direito
+
+Bem-vindo ao `djlinkgen`! Este `README.md` fornece um guia completo para configurar seu ambiente, construir a documentação, personalizar o site e entender o processo de deploy automatizado para o GitHub Pages, que inclui uma página de destino personalizada e a documentação detalhada gerada com MkDocs.
+
+## Visão Geral da Estrutura e Deploy
+
+Este projeto utiliza:
+-   Uma **página de destino personalizada** (`index.html` na raiz do projeto) como ponto de entrada principal do site.
+-   **MkDocs** para gerar um site de documentação estático a partir dos arquivos Markdown localizados no diretório `docs/`.
+-   **GitHub Actions** para automatizar o build e o deploy do site combinado (página de destino + documentação MkDocs) para o GitHub Pages.
+
+Quando implantado, a estrutura no GitHub Pages será:
+-   `https://<username>.github.io/<repository>/`: Exibirá a página de destino personalizada (`index.html`).
+-   `https://<username>.github.io/<repository>/docs/`: Exibirá a documentação gerada pelo MkDocs.
+
+## Pré-requisitos
+
+Antes de começar localmente, certifique-se de ter Python e pip (gerenciador de pacotes Python) instalados.
+
+Instale o MkDocs e o tema Material (e outros plugins se listados no workflow):
+```bash
+pip install mkdocs mkdocs-material
+# Ex: pip install mkdocs-mermaid2 # Se você usa plugins adicionais
+```
+
+## Estrutura do Projeto
+
+-   `mkdocs.yml`: Arquivo de configuração principal do MkDocs. Define navegação, tema, plugins para a documentação em `/docs/`.
+-   `docs/`: Contém os arquivos Markdown da documentação.
+    -   `docs/index.md`: Página inicial da *documentação MkDocs*.
+    -   `docs/css/extra.css` (Opcional): Para CSS personalizado da documentação MkDocs.
+-   `index.html`: Página de destino HTML personalizada (landing page) na raiz do projeto.
+-   `.github/workflows/mkdocs-deploy.yml`: Workflow do GitHub Actions que automatiza o build e deploy.
+-   `site/` (Gerado localmente por `mkdocs build`): Contém a documentação MkDocs construída. **Não é versionado.**
+
+## Desenvolvimento e Visualização Local
+
+### 1. Visualizar a Documentação MkDocs
+Para visualizar e trabalhar na documentação MkDocs (o conteúdo dentro de `/docs/`):
+1.  Navegue até a raiz do projeto.
+2.  Execute:
+    ```bash
+    mkdocs serve
+    ```
+3.  Abra seu navegador em `http://127.0.0.1:8000`. Alterações nos arquivos em `docs/` ou em `mkdocs.yml` recarregarão o site automaticamente.
+
+### 2. Visualizar a Página de Destino Personalizada (`index.html`)
+Abra o arquivo `index.html` diretamente no seu navegador para visualizar e testar as alterações.
+
+## Processo de Deploy Automatizado para GitHub Pages
+
+O deploy é gerenciado pelo workflow em `.github/workflows/mkdocs-deploy.yml`. Ele é acionado a cada `push` para a branch `main`.
+
+**O que o workflow faz:**
+1.  **Checkout do Código:** Baixa a versão mais recente do seu repositório.
+2.  **Configura Python:** Prepara o ambiente Python.
+3.  **Instala Dependências:** Instala `mkdocs`, `mkdocs-material`, etc.
+4.  **Constrói a Documentação MkDocs:** Executa `mkdocs build -d _mkdocssite` para gerar os arquivos da documentação em um diretório específico.
+5.  **Prepara o Diretório de Deploy Final (`public/`):**
+    *   Copia a `index.html` (página de destino personalizada) para a raiz deste diretório (`public/index.html`).
+    *   Copia o conteúdo da documentação MkDocs construída (de `_mkdocssite`) para um subdiretório (`public/docs/`).
+    *   (Opcional) Copia outros arquivos estáticos (como `logo.png`, se existir na raiz) para o diretório `public/`.
+6.  **Implanta no GitHub Pages:** Envia o conteúdo do diretório `public/` para a branch `gh-pages` do seu repositório usando a action `peaceiris/actions-gh-pages`.
+
+O GitHub Pages então serve o conteúdo da branch `gh-pages`.
+
+**(Nota: O workflow em `.github/workflows/mkdocs-deploy.yml` implementa esta estratégia. Consulte o arquivo para ver os detalhes e comandos exatos.)**
+
+## Personalização
+
+### 1. Página de Destino (`index.html`)
+-   **Logo:** Edite o arquivo `index.html`. Procure pelo comentário `LOGO PLACEHOLDER`. Você pode:
+    1.  Substituir o `div.logo-placeholder` por uma tag `<img>` apontando para sua imagem de logo (ex: `<img src="logo.png" alt="djlinkgen Logo">`). Coloque o arquivo `logo.png` na raiz do projeto e certifique-se de que ele é copiado para o diretório `public` durante o passo "Prepare deployment directory" no workflow do GitHub Actions (descomentando a linha relevante em `mkdocs-deploy.yml`).
+    2.  Ou, usar CSS para definir o `background-image` do `div.logo-placeholder` (lembre-se que o caminho da imagem no CSS será relativo à localização do `index.html`).
+-   **Conteúdo e Estilo:** Modifique o HTML e o CSS dentro de `index.html` conforme necessário.
+
+### 2. Documentação MkDocs (`/docs/`)
+-   **`mkdocs.yml`:**
+    *   **Tema e Paleta (`theme`):** Configure nome do tema (`material`), idioma (`language`), cores (`palette`), fontes (`font`), logo para a barra de navegação da documentação (`logo`), favicon (`favicon`).
+    *   **Recursos do Tema (`features`):** Habilite/desabilite recursos do tema Material.
+    *   **Extensões Markdown (`markdown_extensions`):** Adicione funcionalidades ao Markdown.
+-   **CSS Personalizado para Documentação:**
+    *   Crie/edite `docs/css/extra.css`.
+    *   Referencie em `mkdocs.yml`:
+        ```yaml
+        extra_css:
+          - css/extra.css
+        ```
+-   **Modificando Templates do Tema MkDocs (Avançado):**
+    *   Crie um diretório (ex: `docs/overrides` ou `overrides/` na raiz) e adicione seus templates modificados.
+    *   Referencie em `mkdocs.yml`: `theme: name: material, custom_dir: docs/overrides`.
+
+---
+
+Este `README.md` visa fornecer um guia completo para gerenciar e implantar o projeto `djlinkgen`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bem-vindo ao djlinkgen</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            text-align: center;
+        }
+        .container {
+            background-color: #fff;
+            padding: 30px 40px;
+            border-radius: 8px;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+            max-width: 600px;
+        }
+        .logo-placeholder {
+            width: 150px; /* Default width */
+            height: 150px; /* Default height */
+            background-color: #e0e0e0;
+            border: 2px dashed #ccc;
+            margin: 0 auto 20px auto;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            font-size: 0.9em;
+            color: #777;
+        }
+        /* Comment to instruct user: To add your logo, replace the div.logo-placeholder 
+           with an <img> tag, e.g., <img src="logo.png" alt="djlinkgen Logo" style="width: 150px; height: auto;"> 
+           or update the background-image of the div. */
+        h1 {
+            color: #333;
+            margin-bottom: 10px;
+        }
+        p {
+            margin-bottom: 20px;
+            font-size: 1.1em;
+        }
+        .cta-button {
+            display: inline-block;
+            background-color: #007bff; /* Primary blue, change as needed */
+            color: #fff;
+            padding: 12px 25px;
+            text-decoration: none;
+            border-radius: 5px;
+            font-size: 1.1em;
+            transition: background-color 0.3s ease;
+        }
+        .cta-button:hover {
+            background-color: #0056b3; /* Darker blue on hover */
+        }
+        footer {
+            margin-top: 30px;
+            font-size: 0.9em;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <!-- 
+            LOGO PLACEHOLDER:
+            To add your logo, you can either:
+            1. Replace this div with an <img> tag:
+               <img src="path/to/your/logo.png" alt="djlinkgen Logo" style="width: 150px; height: auto; margin-bottom: 20px;">
+            2. Or, if you prefer to use this div, upload your logo (e.g., 'logo.png') to the root directory 
+               and uncomment the following CSS within the <style> tags in the <head>:
+               .logo-placeholder {
+                   background-image: url('logo.png');
+                   background-size: contain;
+                   background-repeat: no-repeat;
+                   background-position: center;
+                   border: none; /* Optional: remove border if logo has its own bounds */
+                   text-indent: -9999px; /* Hide the placeholder text */
+               }
+            Ensure the logo file is in your repository and the path is correct.
+        -->
+        <div class="logo-placeholder">
+            Seu Logo Aqui
+            (150x150px)
+        </div>
+
+        <h1>Bem-vindo ao djlinkgen</h1>
+        <p>Um projeto introdutório de IA generativa aplicada ao Direito.</p>
+        
+        <a href="docs/" class="cta-button">Acessar a Documentação</a>
+        
+    </div>
+    <footer>
+        <p>&copy; <span id="year"></span> djlinkgen. Todos os direitos reservados.</p>
+    </footer>
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces several new features and documentation:

1.  **Custom Landing Page (`index.html`):**
    -   A new `index.html` file is added at the project root to serve as the primary entry point for the site.
    -   It includes a placeholder for a logo and a link to the detailed MkDocs documentation.

2.  **GitHub Actions Workflow (`.github/workflows/mkdocs-deploy.yml`):**
    -   A new workflow is added to automate the build and deployment of the site to GitHub Pages.
    -   The workflow builds the MkDocs site, then prepares a deployment directory (`public/`) where the custom `index.html` is at the root and the MkDocs site is in a `docs/` subdirectory.
    -   This combined structure is then deployed to the `gh-pages` branch.

3.  **Comprehensive README (`README.md`):**
    -   A new `README.md` file is added to the project root.
    -   It details the project structure, local development steps for both the landing page and MkDocs site, the automated deployment process via GitHub Actions, and customization options.